### PR TITLE
Fixed version parsing from "dotnet --info"

### DIFF
--- a/src/compile_test.rs
+++ b/src/compile_test.rs
@@ -193,7 +193,8 @@ lazy_static! {
             panic!("dotnet --info panicked with {stderr}")
         }
         let info = std::str::from_utf8(&info.stdout).expect("Error message not utf8");
-        let version_start = info.find("Version:").unwrap();
+        let version_start = info.find("Host:").unwrap_or_default();
+        let version_start = version_start + &info[version_start..].find("Version:").unwrap();
         let version_start = version_start + "Version:".len();
         let version_end = info.find("Architecture:").unwrap();
         let version = &info[version_start..version_end].trim();


### PR DESCRIPTION
See #6.

Some versions of the dotnet CLI print the current .NET SDK version above the host .NET runtime version. This changes the version parsing to handle this appropriately.

I don't know what the output looks like on the version of the CLI it's supposed to work with, so I made this mostly backwards compatible with the existing parsing strategy. If the output does not include `Host:`, `version_start` will be 0 when the parser scans for `Version:`, which is the same as the prior behavior. This should be fine, unless it's possible to have `Host:` after the version we want to extract (shouldn't be).