### PR TITLE
Added support for adding methods to typedefs

### DIFF
--- a/src/assembly.rs
+++ b/src/assembly.rs
@@ -1,5 +1,4 @@
 use crate::cil_op::{CILOp, CallSite};
-use crate::method::Modifier;
 use crate::{
     access_modifier::AccessModifer, codegen_error::CodegenError, function_sig::FnSig,
     method::Method, r#type::Type, type_def::TypeDef,
@@ -58,7 +57,7 @@ impl Assembly {
         // Get locals
         let locals = locals_from_mir(&mir.local_decls, tcx, sig.inputs().len(), &instance);
         // Create method prototype
-        let mut method = Method::new(access_modifier, vec![Modifier::Static], sig, name, locals);
+        let mut method = Method::new(access_modifier, true, sig, name, locals);
         let mut ops = Vec::new();
         let mut last_bb_id = 0;
         let blocks = &(*mir.basic_blocks);

--- a/src/assembly.rs
+++ b/src/assembly.rs
@@ -1,4 +1,5 @@
 use crate::cil_op::{CILOp, CallSite};
+use crate::method::Modifier;
 use crate::{
     access_modifier::AccessModifer, codegen_error::CodegenError, function_sig::FnSig,
     method::Method, r#type::Type, type_def::TypeDef,
@@ -57,7 +58,7 @@ impl Assembly {
         // Get locals
         let locals = locals_from_mir(&mir.local_decls, tcx, sig.inputs().len(), &instance);
         // Create method prototype
-        let mut method = Method::new(access_modifier, sig, name, locals);
+        let mut method = Method::new(access_modifier, vec![Modifier::Static], sig, name, locals);
         let mut ops = Vec::new();
         let mut last_bb_id = 0;
         let blocks = &(*mir.basic_blocks);

--- a/src/assembly_exporter/ilasm_exporter.rs
+++ b/src/assembly_exporter/ilasm_exporter.rs
@@ -2,7 +2,7 @@ use super::AssemblyExporter;
 use crate::{
     access_modifier::AccessModifer,
     assembly_exporter::AssemblyExportError,
-    method::{Method, Modifier},
+    method::Method,
     r#type::{DotnetTypeRef, Type},
     type_def::TypeDef,
 };
@@ -145,26 +145,20 @@ fn absolute_path(path: &std::path::Path) -> std::io::Result<std::path::PathBuf> 
         Ok(abs_path)
     }
 }
-fn modifier_cil(modifier: &Modifier) -> String {
-    match modifier {
-        Modifier::Static => "static".into(),
-        Modifier::Instance => "instance".into(),
-    }
-}
 fn method_cil(w: &mut impl Write, method: &Method) -> std::io::Result<()> {
     let access = if let AccessModifer::Private = method.access() {
         "private"
     } else {
         "public"
     };
+    let static_inst = if method.is_static() {
+        "static"
+    } else {
+        "instance"
+    };
     let output = output_type_cli(method.sig().output());
     let name = method.name();
-    write!(w, ".method {access} hidebysig ")?;
-    for (_, modifier) in method.modifiers().iter().enumerate() {
-        let modifier_name = modifier_cil(modifier);
-        write!(w, "{modifier_name} ")?;
-    }
-    write!(w, "{output} {name}")?;
+    write!(w, ".method {access} hidebysig {static_inst} {output} {name}")?;
     args_cli(w, method.sig().inputs())?;
     writeln!(w, "{{")?;
     if method.is_entrypoint() {

--- a/src/entrypoint.rs
+++ b/src/entrypoint.rs
@@ -1,7 +1,7 @@
 use crate::{
     cil_op::{CILOp, CallSite},
     function_sig::FnSig,
-    method::Method,
+    method::{Method, Modifier},
     r#type::Type,
 };
 pub fn wrapper(entrypoint: &CallSite) -> Method {
@@ -22,6 +22,7 @@ pub fn wrapper(entrypoint: &CallSite) -> Method {
         ];
         let mut method = Method::new(
             crate::access_modifier::AccessModifer::Public,
+            vec![Modifier::Static],
             sig,
             "entrypoint",
             vec![],

--- a/src/entrypoint.rs
+++ b/src/entrypoint.rs
@@ -1,7 +1,7 @@
 use crate::{
     cil_op::{CILOp, CallSite},
     function_sig::FnSig,
-    method::{Method, Modifier},
+    method::Method,
     r#type::Type,
 };
 pub fn wrapper(entrypoint: &CallSite) -> Method {
@@ -22,7 +22,7 @@ pub fn wrapper(entrypoint: &CallSite) -> Method {
         ];
         let mut method = Method::new(
             crate::access_modifier::AccessModifer::Public,
-            vec![Modifier::Static],
+            true,
             sig,
             "entrypoint",
             vec![],

--- a/src/method.rs
+++ b/src/method.rs
@@ -3,10 +3,16 @@ use crate::{
 };
 use serde::{Deserialize, Serialize};
 use std::hash::{Hash, Hasher};
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Debug)]
+pub enum Modifier {
+    Static,
+    Instance,
+}
 /// Represenation of a CIL method.
 #[derive(Clone, PartialEq, Serialize, Deserialize, Debug)]
 pub struct Method {
     access: AccessModifer,
+    modifiers: Vec<Modifier>,
     sig: FnSig,
     name: IString,
     locals: Vec<Type>,
@@ -25,9 +31,10 @@ pub enum Attribute {
     EntryPoint,
 }
 impl Method {
-    pub fn new(access: AccessModifer, sig: FnSig, name: &str, locals: Vec<Type>) -> Self {
+    pub fn new(access: AccessModifer, modifiers: Vec<Modifier>, sig: FnSig, name: &str, locals: Vec<Type>) -> Self {
         Self {
             access,
+            modifiers,
             sig,
             name: name.into(),
             locals,
@@ -45,6 +52,9 @@ impl Method {
     }
     pub fn access(&self) -> AccessModifer {
         self.access
+    }
+    pub fn modifiers(&self) -> &[Modifier] {
+        &self.modifiers
     }
     pub fn name(&self) -> &str {
         &self.name

--- a/src/method.rs
+++ b/src/method.rs
@@ -3,16 +3,11 @@ use crate::{
 };
 use serde::{Deserialize, Serialize};
 use std::hash::{Hash, Hasher};
-#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Debug)]
-pub enum Modifier {
-    Static,
-    Instance,
-}
 /// Represenation of a CIL method.
 #[derive(Clone, PartialEq, Serialize, Deserialize, Debug)]
 pub struct Method {
     access: AccessModifer,
-    modifiers: Vec<Modifier>,
+    is_static: bool,
     sig: FnSig,
     name: IString,
     locals: Vec<Type>,
@@ -31,10 +26,10 @@ pub enum Attribute {
     EntryPoint,
 }
 impl Method {
-    pub fn new(access: AccessModifer, modifiers: Vec<Modifier>, sig: FnSig, name: &str, locals: Vec<Type>) -> Self {
+    pub fn new(access: AccessModifer, is_static: bool, sig: FnSig, name: &str, locals: Vec<Type>) -> Self {
         Self {
             access,
-            modifiers,
+            is_static,
             sig,
             name: name.into(),
             locals,
@@ -53,8 +48,8 @@ impl Method {
     pub fn access(&self) -> AccessModifer {
         self.access
     }
-    pub fn modifiers(&self) -> &[Modifier] {
-        &self.modifiers
+    pub fn is_static(&self) -> bool {
+        self.is_static
     }
     pub fn name(&self) -> &str {
         &self.name

--- a/src/stdlib.rs
+++ b/src/stdlib.rs
@@ -4,7 +4,7 @@ use crate::{
     assembly::Assembly,
     cil_op::{CILOp, CallSite},
     function_sig::FnSig,
-    method::{Method, Modifier},
+    method::Method,
     r#type::Type,
 };
 macro_rules! add_method {
@@ -12,7 +12,7 @@ macro_rules! add_method {
         fn $name(asm: &mut Assembly) {
             let mut method = Method::new(
                 AccessModifer::Private,
-                vec![Modifier::Static],
+                true,
                 FnSig::new($input, $output),
                 stringify!($name),
                 vec![],
@@ -25,7 +25,7 @@ macro_rules! add_method {
         fn $name(asm: &mut Assembly) {
             let mut method = Method::new(
                 AccessModifer::Private,
-                vec![Modifier::Static],
+                true,
                 FnSig::new($input, $output),
                 stringify!($name),
                 $locals.into(),
@@ -36,11 +36,11 @@ macro_rules! add_method {
     };
 }
 macro_rules! add_tpe_method {
-    ($name:ident,$input:expr,$output:expr,$ops:expr) => {
+    ($name:ident,$is_static:expr,$input:expr,$output:expr,$ops:expr) => {
         fn $name(tpe: &mut crate::type_def::TypeDef) {
             let mut method = Method::new(
                 AccessModifer::Public,
-                vec![Modifier::Instance],
+                $is_static,
                 FnSig::new($input, $output),
                 stringify!($name),
                 vec![],
@@ -53,7 +53,7 @@ macro_rules! add_tpe_method {
         fn $name(tpe: &mut crate::type_def::TypeDef) {
             let mut method = Method::new(
                 AccessModifer::Public,
-                vec![Modifier::Instance],
+                $is_static,
                 FnSig::new($input, $output),
                 stringify!($name),
                 $locals.into(),
@@ -95,6 +95,7 @@ fn rust_slice(asm: &mut Assembly) {
     rust_slice.add_field("_length".into(), Type::ISize);
     add_tpe_method!(
         get_length,
+        false,
         &[],
         &Type::I32,
         [

--- a/src/stdlib.rs
+++ b/src/stdlib.rs
@@ -4,7 +4,7 @@ use crate::{
     assembly::Assembly,
     cil_op::{CILOp, CallSite},
     function_sig::FnSig,
-    method::Method,
+    method::{Method, Modifier},
     r#type::Type,
 };
 macro_rules! add_method {
@@ -12,6 +12,7 @@ macro_rules! add_method {
         fn $name(asm: &mut Assembly) {
             let mut method = Method::new(
                 AccessModifer::Private,
+                vec![Modifier::Static],
                 FnSig::new($input, $output),
                 stringify!($name),
                 vec![],
@@ -24,12 +25,41 @@ macro_rules! add_method {
         fn $name(asm: &mut Assembly) {
             let mut method = Method::new(
                 AccessModifer::Private,
+                vec![Modifier::Static],
                 FnSig::new($input, $output),
                 stringify!($name),
                 $locals.into(),
             );
             method.set_ops(($ops).into());
             asm.add_method(method);
+        }
+    };
+}
+macro_rules! add_tpe_method {
+    ($name:ident,$input:expr,$output:expr,$ops:expr) => {
+        fn $name(tpe: &mut crate::type_def::TypeDef) {
+            let mut method = Method::new(
+                AccessModifer::Public,
+                vec![Modifier::Instance],
+                FnSig::new($input, $output),
+                stringify!($name),
+                vec![],
+            );
+            method.set_ops(($ops).to_vec());
+            tpe.add_method(method);
+        }
+    };
+    ($name:ident,$input:expr,$output:expr,$ops:expr,$locals:expr) => {
+        fn $name(tpe: &mut crate::type_def::TypeDef) {
+            let mut method = Method::new(
+                AccessModifer::Public,
+                vec![Modifier::Instance],
+                FnSig::new($input, $output),
+                stringify!($name),
+                $locals.into(),
+            );
+            method.set_ops(($ops).into());
+            tpe.add_method(method);
         }
     };
 }
@@ -48,15 +78,33 @@ pub fn insert_libc(asm: &mut Assembly) {
     asm.add_typedef(crate::type_def::TypeDef::nameonly("RustVoid"));
     asm.add_typedef(crate::type_def::TypeDef::nameonly("Foreign"));
     asm.add_typedef(crate::type_def::TypeDef::nameonly("RustStr"));
-    let mut rust_slice = crate::type_def::TypeDef::nameonly("RustSlice");
-    rust_slice.set_generic_count(1);
-    asm.add_typedef(rust_slice);
+    rust_slice(asm);
     math(asm);
     io(asm);
     malloc(asm);
     realloc(asm);
     free(asm);
     abort(asm);
+}
+
+fn rust_slice(asm: &mut Assembly) {
+    let mut rust_slice = crate::type_def::TypeDef::nameonly("RustSlice");
+    rust_slice.set_generic_count(1);
+    // TODO: constrain this generic to be unmanaged
+    rust_slice.add_field("_ptr".into(), Type::Ptr(Box::new(Type::GenericArg(0))));
+    rust_slice.add_field("_length".into(), Type::ISize);
+    add_tpe_method!(
+        get_length,
+        &[],
+        &Type::I32,
+        [
+            // just returning 0 for now
+            CILOp::LdcI32(0),
+            CILOp::Ret
+        ]
+    );
+    get_length(&mut rust_slice);
+    asm.add_typedef(rust_slice);
 }
 
 fn math(asm: &mut Assembly) {

--- a/src/type_def.rs
+++ b/src/type_def.rs
@@ -2,7 +2,7 @@ use crate::{
     access_modifier::AccessModifer,
     r#type::{DotnetTypeRef, Type},
     utilis::{enum_tag_size, tag_from_enum_variants},
-    IString,
+    IString, method::Method,
 };
 use rustc_middle::ty::{AdtDef, AdtKind, GenericArg, List, Ty, TyCtxt, TyKind};
 use serde::{Deserialize, Serialize};
@@ -12,6 +12,7 @@ pub struct TypeDef {
     name: IString,
     inner_types: Vec<Self>,
     fields: Vec<(IString, Type)>,
+    functions: Vec<Method>,
     explicit_offsets: Option<Vec<u32>>,
     gargc: u32,
     extends: Option<DotnetTypeRef>,
@@ -35,11 +36,20 @@ impl TypeDef {
     pub fn fields(&self) -> &[(IString, Type)] {
         &self.fields
     }
+    pub fn add_field(&mut self, name: IString, tpe: Type) {
+        self.fields.push((name, tpe));
+    }
     pub fn inner_types(&self) -> &[Self] {
         &self.inner_types
     }
     pub fn explicit_offsets(&self) -> Option<&Vec<u32>> {
         self.explicit_offsets.as_ref()
+    }
+    pub fn add_method(&mut self, method: Method) {
+        self.functions.push(method);
+    }
+    pub fn methods(&self) -> impl Iterator<Item = &Method> {
+        self.functions.iter()
     }
     pub fn nameonly(name: &str) -> Self {
         Self {
@@ -47,6 +57,7 @@ impl TypeDef {
             name: name.into(),
             inner_types: vec![],
             fields: vec![],
+            functions: vec![],
             gargc: 0,
             extends: None,
             explicit_offsets: None,
@@ -80,6 +91,7 @@ impl TypeDef {
                     name: name.into(),
                     inner_types: vec![],
                     fields,
+                    functions: vec![],
                     explicit_offsets: None,
                     gargc: 1,
                     extends: None,
@@ -125,6 +137,7 @@ impl TypeDef {
             name,
             inner_types: vec![],
             fields,
+            functions: vec![],
             gargc,
             extends: None,
             explicit_offsets: None,
@@ -162,6 +175,7 @@ impl TypeDef {
             name,
             inner_types: vec![],
             fields,
+            functions: vec![],
             gargc,
             extends: None,
             explicit_offsets,
@@ -219,6 +233,7 @@ impl TypeDef {
                 name: variant_name.into(),
                 inner_types: vec![],
                 fields,
+                functions: vec![],
                 gargc,
                 extends: None,
                 explicit_offsets: None,
@@ -229,6 +244,7 @@ impl TypeDef {
             name,
             inner_types,
             fields,
+            functions: vec![],
             gargc,
             extends: None,
             explicit_offsets: Some(explicit_offsets),


### PR DESCRIPTION
Prerequisite for #13.

- Added configurable modifiers (currently just static/instance)
- Added support for adding methods to typedefs
- Added some fields/a dummy method to `RustSlice` as an example
- Fixed a few warnings

IL output:
```
.class public RustSlice<G0> extends [System.Runtime]System.ValueType{
	.field public !G0* _ptr
	.field public native int _length
.method public hidebysig instance int32 get_length(){
	.locals (

	)
	ldc.i4.0
	ret
}
}
```

I've started getting some weird type load errors in the exe tests (even after reverting to a known-good commit) so I don't know if those pass, but the dll tests that were passing before all pass after this change. Going to look into that separately, it's probably related to my devcontainer dotnet config somehow.

Example of a failing test, for reference:
```
---- compile_test::structs stdout ----
"./test/types//../structs.runtimeconfig.json"
thread 'compile_test::structs' panicked at src/compile_test.rs:34:9:
Test program failed with message Unhandled exception. System.TypeLoadException: Could not load type 'System.Runtime.InteropServices.Marshal' from assembly 'asm, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null' due to value type mismatch.
   at malloc(UIntPtr A_0)
   at _ZN7structs4main17hfd21829ca5bc033cE()
   at _ZN7structs5start17h57dad123f3e53cbeE(IntPtr A_0, Byte** A_1)
   at entrypoint()
```