### PR TITLE
Added support for indexing slices/arrays

### DIFF
--- a/src/type.rs
+++ b/src/type.rs
@@ -239,6 +239,7 @@ impl From<&FloatTy> for Type {
 pub fn element_type<'tyctx>(src: Ty<'tyctx>) -> Ty<'tyctx> {
     match src.kind() {
         TyKind::Array(element, _) => *element,
+        TyKind::Slice(element) => *element,
         _ => panic!("Can't get element type of {src:?}"),
     }
 }

--- a/test/assign.rs
+++ b/test/assign.rs
@@ -1,3 +1,5 @@
+#![allow(improper_ctypes_definitions)]
+
 #[no_mangle]
 pub extern fn assign_i8(place: &mut i8, value: &i8) {
     *place = *value;
@@ -66,4 +68,14 @@ pub extern fn assign_bool(place: &mut bool, value: &bool) {
 #[no_mangle]
 pub extern fn assign_char(place: &mut char, value: &char) {
     *place = *value;
+}
+
+#[no_mangle]
+pub extern fn assign_array_elem(place: &mut [u8; 1], value: &[u8; 1]) {
+    place[0] = value[0];
+}
+
+#[no_mangle]
+pub extern fn assign_slice_elem(place: &mut [u8], value: &[u8]) {
+    place[0] = value[0];
 }


### PR DESCRIPTION
Closes #13.

This adds support for getting/setting values at indices in slices and arrays. Some of the `stdlib` syntax is a bit awkward right now because of some instructions expecting `TypeDef` and others expecting `DotnetTypeDef`, but I figured that could be handled in a future PR.

For the slice methods, I just wrote a reference implementation in C# (without auto-properties or `StructLayout`, for simplicity) and copied over the .NET output.

#### Codegen comparisons

Reference:
```csharp
internal unsafe struct RustSlice<G0> where G0 : unmanaged
{
    private G0* _ptr;
    private nuint _length;

    public nuint Length => _length;

    public G0 this[nuint offset]
    {
        get => _ptr[offset];
        set => _ptr[offset] = value;
    }
}
```

.NET 7.0.401:
```
.class private sealed sequential ansi beforefieldinit
  RustSlice`1<valuetype .ctor (class [System.Runtime]System.ValueType modreq ([System.Runtime]System.Runtime.InteropServices.UnmanagedType)) G0>
    extends [System.Runtime]System.ValueType
{
  .custom instance void [System.Runtime]System.Reflection.DefaultMemberAttribute::.ctor(string)
    = (01 00 04 49 74 65 6d 00 00 ) // ...Item..
    // string('Item')
  .param type [1] /*G0*/
    .custom instance void System.Runtime.CompilerServices.IsUnmanagedAttribute::.ctor()
      = (01 00 00 00 )

  .field private !0/*G0*/* _ptr

  .field private native unsigned int _length

  .method public hidebysig specialname instance native unsigned int
    get_Length() cil managed
  {
    .maxstack 8

    // [42 28 - 42 35]
    IL_0000: ldarg.0      // this
    IL_0001: ldfld        native unsigned int valuetype RustSlice`1<!0/*G0*/>::_length
    IL_0006: ret

  } // end of method RustSlice`1::get_Length

  .method public hidebysig specialname instance !0/*G0*/
    get_Item(
      native unsigned int offset
    ) cil managed
  {
    .maxstack 8

    // [46 16 - 46 28]
    IL_0000: ldarg.0      // this
    IL_0001: ldfld        !0/*G0*/* valuetype RustSlice`1<!0/*G0*/>::_ptr
    IL_0006: ldarg.1      // offset
    IL_0007: conv.u8
    IL_0008: sizeof       !0/*G0*/
    IL_000e: conv.i8
    IL_000f: mul
    IL_0010: conv.u
    IL_0011: add
    IL_0012: ldobj        !0/*G0*/
    IL_0017: ret

  } // end of method RustSlice`1::get_Item

  .method public hidebysig specialname instance void
    set_Item(
      native unsigned int offset,
      !0/*G0*/ 'value'
    ) cil managed
  {
    .maxstack 8

    // [47 16 - 47 36]
    IL_0000: ldarg.0      // this
    IL_0001: ldfld        !0/*G0*/* valuetype RustSlice`1<!0/*G0*/>::_ptr
    IL_0006: ldarg.1      // offset
    IL_0007: conv.u8
    IL_0008: sizeof       !0/*G0*/
    IL_000e: conv.i8
    IL_000f: mul
    IL_0010: conv.u
    IL_0011: add
    IL_0012: ldarg.2      // 'value'
    IL_0013: stobj        !0/*G0*/
    IL_0018: ret

  } // end of method RustSlice`1::set_Item

  .property instance native unsigned int Length()
  {
    .get instance native unsigned int RustSlice`1::get_Length()
  } // end of property RustSlice`1::Length

  .property instance !0/*G0*/ Item(native unsigned int)
  {
    .get instance !0/*G0*/ RustSlice`1::get_Item(native unsigned int)
    .set instance void RustSlice`1::set_Item(native unsigned int, !0/*G0*/)
  } // end of property RustSlice`1::Item
} // end of class RustSlice`1
```

rustc_codegen_clr:
```
.class public RustSlice<G0> extends [System.Runtime]System.ValueType{
	.field public !G0* _ptr
	.field public native int _length
.method public hidebysig instance native uint get_Length(valuetype RustSlice<!G0>){
	.locals (

	)
	ldarg.0
	ldfld native uint valuetype RustSlice<!G0>::_length
	ret
}
.method public hidebysig instance !G0 get_Item(valuetype RustSlice<!G0>,native uint){
	.locals (

	)
	ldarg.0
	ldfld !0* valuetype RustSlice<!G0>::_ptr
	ldarg.1
	conv.u8
	sizeof !G0
	conv.i8
	mul
	conv.u
	add
	ldobj valuetype !0
	ret
}
.method public hidebysig instance void set_Item(valuetype RustSlice<!G0>,native uint,!G0){
	.locals (

	)
	ldarg.0
	ldfld !0* valuetype RustSlice<!G0>::_ptr
	ldarg.1
	conv.u8
	sizeof !G0
	conv.i8
	mul
	conv.u
	add
	ldarg.2
	stobj valuetype !0
	ret
}
}
```