### PR TITLE
Added support for dereferencing tuples behind refs

### DIFF
--- a/src/place.rs
+++ b/src/place.rs
@@ -441,7 +441,13 @@ fn ptr_set_op<'ctx>(curr_type: PlaceTy<'ctx>, tyctx: TyCtxt<'ctx>) -> Vec<CILOp>
                 vec![CILOp::STObj(
                     crate::r#type::Type::from_ty(curr_type, tyctx).into(),
                 )]
-            }
+            },
+            TyKind::Tuple(_) => {
+                // This is interpreted as a System.ValueTuple and can be treated as an ADT
+                vec![CILOp::STObj(
+                    crate::r#type::Type::from_ty(curr_type, tyctx).into(),
+                )]
+            },
             TyKind::Ref(_, _, _) => vec![CILOp::STIndISize],
             TyKind::RawPtr(_) => vec![CILOp::STIndISize],
             _ => todo!(" can't deref type {curr_type:?} yet"),
@@ -481,7 +487,13 @@ pub fn deref_op<'ctx>(curr_type: PlaceTy<'ctx>, tyctx: TyCtxt<'ctx>) -> Vec<CILO
                 vec![CILOp::LdObj(
                     crate::r#type::Type::from_ty(curr_type, tyctx).into(),
                 )]
-            }
+            },
+            TyKind::Tuple(_) => {
+                // This is interpreted as a System.ValueTuple and can be treated as an ADT
+                vec![CILOp::LdObj(
+                    crate::r#type::Type::from_ty(curr_type, tyctx).into(),
+                )]
+            },
             TyKind::Ref(_, _, _) => vec![CILOp::LDIndISize],
             TyKind::RawPtr(_) => vec![CILOp::LDIndISize],
             _ => todo!("TODO: can't deref type {curr_type:?} yet"),

--- a/test/assign.rs
+++ b/test/assign.rs
@@ -79,3 +79,8 @@ pub extern fn assign_array_elem(place: &mut [u8; 1], value: &[u8; 1]) {
 pub extern fn assign_slice_elem(place: &mut [u8], value: &[u8]) {
     place[0] = value[0];
 }
+
+#[no_mangle]
+pub extern fn assign_tuple(place: &mut (u8, u8), value: &(u8, u8)) {
+    *place = *value;
+}


### PR DESCRIPTION
This adds support for storing/loading tuples behind references. Tuples are already marshalled as `System.ValueTuple`, so I just duplicated the ADT logic for them.