### PR TITLE
chore: Add rust-toolchain for easier dev setup

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "nightly"
+components = ["rustfmt", "clippy", "rust-src", "rustc-dev", "llvm-tools-preview"]


### PR DESCRIPTION
Part of https://github.com/FractalFir/rustc_codegen_clr/issues/25

This PR introduces a rust-toolchain.toml file that specifies all the necessary components.

So users don't need to call `rustup default nightly` or `rustup component add` anymore.