### PR TITLE
Add support of macOS platforms

### DIFF
--- a/src/bin/linker/main.rs
+++ b/src/bin/linker/main.rs
@@ -150,6 +150,10 @@ fn get_libc() -> String {
 fn get_libc() -> String {
     "ucrtbase.dll".into()
 }
+#[cfg(target_os = "macos")]
+fn get_libc() -> String {
+    "libSystem.B.dylib".into()
+}
 fn main() {
     // Parse command line arguments
 


### PR DESCRIPTION
Currently `get_libc()` is not implemented for macOS in `src/bin/linker/main.rs`, so we will get an error compiling on macOS platforms due to lack of that function.

This PR implements `get_libc()` for `#[cfg(target_os = "macos)]"`. The implementation just simply returns `"libSystem.B.dylib".into()`.