### PR TITLE
README.md: fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ As you can see, the difference between optimized C# and optimized .NET Rust code
 
 ### Q: Compatibility?
 
-**A**: *`rustc_codegen_clr` is only tested on Linux x86_64, with the Mono and CoreCLR (more commonly known as simply the .NET runtime). It may should on other platforms, but it is not guaranteed.
+**A**: *`rustc_codegen_clr` is only tested on Linux x86_64, with the Mono and CoreCLR (more commonly known as simply the .NET runtime). It should work on other platforms, but it is not guaranteed.
 
 **A** The support for the Mono runtime is not as good as it could be. Due to not supported features and differences, 128-bit integers and checked 64-bit integer arithmetic are not supported on Mono.
 


### PR DESCRIPTION
Introduced in d1ed748fa45cea3f070698d9b50b45c1ecfd0267.