### PR TITLE
Add `core::intrinsics::transmute` intrinsics test

### DIFF
--- a/src/compile_test.rs
+++ b/src/compile_test.rs
@@ -754,6 +754,7 @@ run_test! {intrinsics,copy_nonoverlaping,stable}
 run_test! {intrinsics,ptr_offset_from_unsigned,stable}
 run_test! {intrinsics,arith_offset,stable}
 run_test! {intrinsics,cmp_bytes,stable}
+run_test! {intrinsics,transmute,stable}
 
 run_test! {alloc,abox,stable}
 run_test! {alloc,raw_vec,stable}

--- a/test/intrinsics/transmute.rs
+++ b/test/intrinsics/transmute.rs
@@ -1,0 +1,36 @@
+#![feature(
+    lang_items,
+    adt_const_params,
+    associated_type_defaults,
+    core_intrinsics,
+    start,
+    unsized_const_params
+)]
+#![allow(internal_features, incomplete_features, unused_variables, dead_code)]
+#![no_std]
+include!("../common.rs");
+extern crate core;
+
+use core::intrinsics::transmute;
+
+fn main() {
+    let slice = unsafe { transmute::<&str, &[u8]>(".NET") };
+    test_eq!(black_box(slice), &[46, 78, 69, 84]);
+
+    fn forty_two() -> i32 {
+        42
+    }
+    let pointer = forty_two as *const ();
+    let function = unsafe {
+        transmute::<*const (), fn() -> i32>(pointer)
+    };
+    test_eq!(function(), black_box(42));
+
+
+    let ptr_i32: &mut i32 = &mut 3;
+    let transmuted_to_u32: &mut u32 = unsafe {
+        transmute::<&mut i32, &mut u32>(ptr_i32)
+    };
+    let ptr_u32: &mut u32 = &mut 3;
+    test_eq!(transmuted_to_u32, black_box(ptr_u32));
+}


### PR DESCRIPTION
Part of #45.

Presenting this to narrow down if this is what you are looking for in intrinsics tests. The 3 `transmute` test cases are inspired from the `transmute` official docs. 

A possible improvement I noticed for the test suite is the wall of:

```rs
// snip
run_test! {intrinsics,ctpop,stable}
run_test! {intrinsics,atomics,stable}
run_test! {intrinsics,alloc,stable}
run_test! {intrinsics,size_of_val,stable}
run_test! {intrinsics,malloc,stable}
run_test! {intrinsics,offset_of,stable}
// snip
```

in `compile_test.rs`. Addressing this could be the subject of another PR.