### PR TITLE
Rename struct_tail_erasing_lifetimes to struct_tail_for_codegen

### DIFF
--- a/src/unsize.rs
+++ b/src/unsize.rs
@@ -400,7 +400,7 @@ pub(crate) fn unsized_info<'tcx>(
 ) -> CILNode {
     let (source, target) =
         fx.tcx()
-            .struct_lockstep_tails_erasing_lifetimes(source, target, ParamEnv::reveal_all());
+            .struct_lockstep_tails_for_codegen(source, target, ParamEnv::reveal_all());
     match (&source.kind(), &target.kind()) {
         (&TyKind::Array(_, len), &TyKind::Slice(_)) => conv_usize!(ldc_i64!(len
             .eval_target_usize(fx.tcx(), ParamEnv::reveal_all())


### PR DESCRIPTION
Updating to the latest Rust nightly compiler,
[Ref](https://github.com/rust-lang/rustc_codegen_cranelift/commit/e96ece7c0bf59cbf21e39585027aab30dc753d0c)